### PR TITLE
Fix #20

### DIFF
--- a/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
+++ b/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
@@ -29,7 +29,7 @@ public class OpenAppstorePlugin implements MethodCallHandler {
       result.success("Android " + android.os.Build.VERSION.RELEASE);
     }
     else if (call.method.equals("openappstore")) {
-      result.success("Android " + android.os.Build.VERSION.RELEASE);	      String android_id = call.argument("android_id");
+      String android_id = call.argument("android_id");
       try {
         mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + android_id)));
       } catch (android.content.ActivityNotFoundException e) {

--- a/lib/open_appstore.dart
+++ b/lib/open_appstore.dart
@@ -12,7 +12,11 @@ class OpenAppstore {
   }
 
   static void launch({String androidAppId, String iOSAppId}) async {
-    await _channel.invokeMethod(
+    try {
+      await _channel.invokeMethod(
         'openappstore', {'android_id': androidAppId, 'ios_id':iOSAppId});
+    } on PlatformException catch (e) {
+       throw StateError(e.toString());
+    }
   }
 }


### PR DESCRIPTION
Fixes issue #20 (which still occurs on Android; this was caused by sending 2 success calls instead of 1). Also, allow developer to enclose OpenAppstore.launch() in a try-catch block so the developer can decide how to handle future errors.