### PR TITLE
Add Amazon Appstore link

### DIFF
--- a/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
+++ b/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
@@ -29,12 +29,18 @@ public class OpenAppstorePlugin implements MethodCallHandler {
       result.success("Android " + android.os.Build.VERSION.RELEASE);
     }
     else if (call.method.equals("openappstore")) {
-      result.success("Android " + android.os.Build.VERSION.RELEASE);	      String android_id = call.argument("android_id");
-      try {
-        mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + android_id)));
-      } catch (android.content.ActivityNotFoundException e) {
-        mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + android_id)));
-      }
+      result.success("Android " + android.os.Build.VERSION.RELEASE);
+      String android_id = call.argument("android_id");
+      String manufacturer = android.os.Build.MANUFACTURER;
+      if (manufacturer.equals("Amazon")) {
+        mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("amzn://apps/android?p=" + android_id)));
+      } else {
+        try {
+          mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + android_id)));
+        } catch (android.content.ActivityNotFoundException e) {
+          mRegistrar.activity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + android_id)));
+        }
+    }
       result.success(null);
     }
     else {


### PR DESCRIPTION
As most Amazon devices don't allow native support for the Play Store and instead rely on the Amazon Appstore. I added an extra conditional that checks the device's manufacturer so the appropriate store will be opened.