### PR TITLE
Fix java.lang.IllegalStateException: Reply already submitted

### DIFF
--- a/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
+++ b/android/src/main/java/flutter/moum/open_appstore/OpenAppstorePlugin.java
@@ -48,7 +48,6 @@ public class OpenAppstorePlugin implements FlutterPlugin {
               context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + android_id)));
             }
           }
-          result.success(null);
         }
         else {
           result.notImplemented();


### PR DESCRIPTION
On line 39 there is always a result.success call so this fixes the error